### PR TITLE
Add Catomic Bomb card

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 
     <!-- release parent settings -->
-    <version.java>11</version.java>
+    <version.java>17</version.java>
     <nexus.snapshot.repository>
       https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
     </nexus.snapshot.repository>

--- a/src/main/java/io/zeebe/bpmn/games/GameListener.java
+++ b/src/main/java/io/zeebe/bpmn/games/GameListener.java
@@ -48,6 +48,8 @@ public interface GameListener {
 
   void gameCanceled(Context context);
 
+  void explodingKittensMovedToTopOfDeck(Context context, List<Card> deck);
+
   interface Context {
     String getKey();
 

--- a/src/main/java/io/zeebe/bpmn/games/GameStateLogger.java
+++ b/src/main/java/io/zeebe/bpmn/games/GameStateLogger.java
@@ -122,4 +122,9 @@ public class GameStateLogger implements GameListener {
   public void gameCanceled(final Context context) {
     LOG.debug("The game is canceled.");
   }
+
+  @Override
+  public void explodingKittensMovedToTopOfDeck(Context context, List<Card> deck) {
+    LOG.debug("All exploding kittens are placed at the top of the deck {}", deck);
+  }
 }

--- a/src/main/java/io/zeebe/bpmn/games/deck/BuildDeck.java
+++ b/src/main/java/io/zeebe/bpmn/games/deck/BuildDeck.java
@@ -34,7 +34,8 @@ public class BuildDeck implements JobHandler {
           CardType.DRAW_FROM_BOTTOM, List.of(3, 4, 7),
           CardType.FAVOR, List.of(2, 4, 6),
           CardType.NOPE, List.of(4, 6, 10),
-          CardType.DEFUSE, List.of(3, 7, 10));
+          CardType.DEFUSE, List.of(3, 7, 10),
+          CardType.ATOMIC, List.of(1, 1, 1));
 
   private final Map<CardType, List<Integer>> catCards =
       Map.of(

--- a/src/main/java/io/zeebe/bpmn/games/model/CardType.java
+++ b/src/main/java/io/zeebe/bpmn/games/model/CardType.java
@@ -5,6 +5,7 @@ public enum CardType {
   // special
   EXPLODING,
   DEFUSE,
+  ATOMIC,
 
   // actions
   ATTACK,

--- a/src/main/java/io/zeebe/bpmn/games/slack/SlackGameStateNotifier.java
+++ b/src/main/java/io/zeebe/bpmn/games/slack/SlackGameStateNotifier.java
@@ -289,4 +289,9 @@ public class SlackGameStateNotifier implements GameListener {
 
     gameEnded(context);
   }
+
+    @Override
+    public void explodingKittensMovedToTopOfDeck(Context context, List<Card> deck) {
+        sendMessage(context, user -> "All exploding kittens are placed at the top of the deck!");
+    }
 }

--- a/src/main/java/io/zeebe/bpmn/games/slack/SlackUtil.java
+++ b/src/main/java/io/zeebe/bpmn/games/slack/SlackUtil.java
@@ -10,42 +10,24 @@ import java.util.stream.Collectors;
 
 public class SlackUtil {
 
-  private static final Map<CardType, String> cardEmojis1 =
-      Map.of(
-          CardType.EXPLODING, ":bpmn-error-throw-event-red:",
-          CardType.DEFUSE, ":bpmn-error-catch-event-green:",
-          CardType.ATTACK, ":bpmn-parallel-gateway-purple:",
-          CardType.SEE_THE_FUTURE, ":bpmn-timer-catch-event-blue:",
-          CardType.ALTER_THE_FUTURE, ":bpmn-compensation-throw-event-blue:",
-          CardType.DRAW_FROM_BOTTOM, ":bpmn-escalation-throw-event-blue:",
-          CardType.SHUFFLE, ":bpmn-complex-gateway-blue:",
-          CardType.SKIP, ":bpmn-link-throw-event-blue:",
-          CardType.NOPE, ":bpmn-cancel-throw-event-yellow:",
-          CardType.FAVOR, ":bpmn-receive-task:");
-
-  private static final Map<CardType, String> cardEmojis2 =
-      Map.of(
-          CardType.FERAL_CAT,
-          ":bpmn-none-task:",
-          CardType.CAT_1,
-          ":bpmn-user-task:",
-          CardType.CAT_2,
-          ":bpmn-manual-task:",
-          CardType.CAT_3,
-          ":bpmn-service-task:",
-          CardType.CAT_4,
-          ":bpmn-script-task:",
-          CardType.CAT_5,
-          ":bpmn-business-rule-task:");
-
-  private static final Map<CardType, String> cardEmojis;
-
-  static {
-    cardEmojis = new HashMap<>();
-    cardEmojis.putAll(cardEmojis1);
-    cardEmojis.putAll(cardEmojis2);
-  }
-  ;
+  private static final Map<CardType, String> cardEmojis = Map.ofEntries(
+          Map.entry(CardType.EXPLODING, ":bpmn-error-throw-event-red:"),
+          Map.entry(CardType.DEFUSE, ":bpmn-error-catch-event-green:"),
+          Map.entry(CardType.ATTACK, ":bpmn-parallel-gateway-purple:"),
+          Map.entry(CardType.SEE_THE_FUTURE, ":bpmn-timer-catch-event-blue:"),
+          Map.entry(CardType.ALTER_THE_FUTURE, ":bpmn-compensation-throw-event-blue:"),
+          Map.entry(CardType.DRAW_FROM_BOTTOM, ":bpmn-escalation-throw-event-blue:"),
+          Map.entry(CardType.SHUFFLE, ":bpmn-complex-gateway-blue:"),
+          Map.entry(CardType.SKIP, ":bpmn-link-throw-event-blue:"),
+          Map.entry(CardType.NOPE, ":bpmn-cancel-throw-event-yellow:"),
+          Map.entry(CardType.FAVOR, ":bpmn-receive-task:"),
+          Map.entry(CardType.FERAL_CAT, ":bpmn-none-task:"),
+          Map.entry(CardType.CAT_1, ":bpmn-user-task:"),
+          Map.entry(CardType.CAT_2, ":bpmn-manual-task:"),
+          Map.entry(CardType.CAT_3, ":bpmn-service-task:"),
+          Map.entry(CardType.CAT_4, ":bpmn-script-task:"),
+          Map.entry(CardType.CAT_5, ":bpmn-business-rule-task:"),
+          Map.entry(CardType.ATOMIC, ":bpmn-termination-end-event:"));
 
   public static String formatCard(Card card) {
     final var type = card.getType();

--- a/src/main/java/io/zeebe/bpmn/games/slack/SlashCommands.java
+++ b/src/main/java/io/zeebe/bpmn/games/slack/SlashCommands.java
@@ -199,7 +199,9 @@ public class SlashCommands {
                                 "end your turn and the next player has additional turns (your remaining turns + 2)")
                             + format.apply(
                                 CardType.NOPE,
-                                "invalid the last played card (the action is not applied) - can be chained to undo the nope"))
+                                "invalid the last played card (the action is not applied) - can be chained to undo the nope")
+                            + format.apply(CardType.ATOMIC,
+                                "shuffle the deck and put all exploding kittens on top - end your turn (without drawing)"))
                     .build())
             .build());
 

--- a/src/main/java/io/zeebe/bpmn/games/user/AtomicAction.java
+++ b/src/main/java/io/zeebe/bpmn/games/user/AtomicAction.java
@@ -1,0 +1,46 @@
+package io.zeebe.bpmn.games.user;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.spring.client.annotation.ZeebeWorker;
+import io.zeebe.bpmn.games.GameContext;
+import io.zeebe.bpmn.games.GameListener;
+import io.zeebe.bpmn.games.model.CardType;
+import io.zeebe.bpmn.games.model.Variables;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AtomicAction implements JobHandler {
+
+  private final GameListener listener;
+
+  @Autowired
+  public AtomicAction(GameListener listener) {
+    this.listener = listener;
+  }
+
+  @ZeebeWorker(type = "atomic")
+  @Override
+  public void handle(JobClient jobClient, ActivatedJob job) throws Exception {
+    final var variables = Variables.from(job);
+
+    final var deck = variables.getDeck();
+    // Move all exploding cards to the top of the deck
+    final var explodingKittens =
+        deck.stream().filter(card -> card.getType() == CardType.EXPLODING).toList();
+    deck.removeAll(explodingKittens);
+    deck.addAll(0, explodingKittens);
+
+    variables.putDeck(deck);
+
+    listener.explodingKittensMovedToTopOfDeck(GameContext.of(job), deck);
+
+    jobClient
+        .newCompleteCommand(job.getKey())
+        .variables(variables.getResultVariables())
+        .send()
+        .join();
+  }
+}

--- a/src/main/resources/exploding-kittens-action.bpmn
+++ b/src/main/resources/exploding-kittens-action.bpmn
@@ -2,6 +2,11 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1c0uu3w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
   <bpmn:process id="exploding-kittens-action" name="Exploding Kittens: Apply a card action" isExecutable="true">
     <bpmn:startEvent id="Event_1m08pf0" name="Apply Action">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=false" target="endTurn" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
       <bpmn:outgoing>Flow_0figpgf</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:exclusiveGateway id="Gateway_1pqfwv5" name="Which action?">
@@ -78,7 +83,8 @@
       <bpmn:incoming>Flow_1pvbc88</bpmn:incoming>
       <bpmn:incoming>Flow_1pyk8o2</bpmn:incoming>
       <bpmn:incoming>Flow_1xnd7rf</bpmn:incoming>
-      <bpmn:incoming>Flow_1igrzok</bpmn:incoming>
+      <bpmn:incoming>Flow_13r2ts0</bpmn:incoming>
+      <bpmn:incoming>Flow_0g09equ</bpmn:incoming>
       <bpmn:outgoing>Flow_0n68dzy</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="Event_0mubhxj" name="Action applied">
@@ -123,13 +129,9 @@
     <bpmn:sequenceFlow id="Flow_1pyk8o2" sourceRef="Activity_0tst3a6" targetRef="Gateway_0547r8f" />
     <bpmn:sequenceFlow id="Flow_1xnd7rf" sourceRef="Activity_1pdtlxj" targetRef="Gateway_0547r8f" />
     <bpmn:sequenceFlow id="Flow_0n68dzy" sourceRef="Gateway_0547r8f" targetRef="Event_0mubhxj" />
-    <bpmn:sequenceFlow id="Flow_1nxsygr" name="Skip" sourceRef="Gateway_1pqfwv5" targetRef="Event_02gf3ei">
+    <bpmn:sequenceFlow id="Flow_1nxsygr" name="Skip" sourceRef="Gateway_1pqfwv5" targetRef="Activity_167c1gq">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= action = "skip"</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:endEvent id="Event_02gf3ei" name="Skip">
-      <bpmn:incoming>Flow_1nxsygr</bpmn:incoming>
-      <bpmn:errorEventDefinition id="ErrorEventDefinition_1blz0pq" errorRef="Error_0nbjl10" />
-    </bpmn:endEvent>
     <bpmn:endEvent id="Event_07db4i1" name="Draw from Bottom">
       <bpmn:incoming>Flow_0qpt4bc</bpmn:incoming>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_1k1rfgi" errorRef="Error_0gl9bie" />
@@ -160,9 +162,25 @@
         <zeebe:taskDefinition type="atomic" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1rqecyx</bpmn:incoming>
-      <bpmn:outgoing>Flow_1igrzok</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0gl18c0</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1igrzok" sourceRef="Activity_0ogwlow" targetRef="Gateway_0547r8f" />
+    <bpmn:scriptTask id="Activity_167c1gq" name="Set endTurn to true">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=true" resultVariable="endTurn" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nxsygr</bpmn:incoming>
+      <bpmn:outgoing>Flow_13r2ts0</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_13r2ts0" sourceRef="Activity_167c1gq" targetRef="Gateway_0547r8f" />
+    <bpmn:sequenceFlow id="Flow_0gl18c0" sourceRef="Activity_0ogwlow" targetRef="Activity_1b9lhg4" />
+    <bpmn:sequenceFlow id="Flow_0g09equ" sourceRef="Activity_1b9lhg4" targetRef="Gateway_0547r8f" />
+    <bpmn:scriptTask id="Activity_1b9lhg4" name="Set endTurn to true">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=true" resultVariable="endTurn" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0gl18c0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0g09equ</bpmn:outgoing>
+    </bpmn:scriptTask>
   </bpmn:process>
   <bpmn:error id="Error_0nbjl10" name="skip" errorCode="skip" />
   <bpmn:error id="Error_0fp8pba" name="attack" errorCode="attack" />
@@ -217,12 +235,6 @@
       <bpmndi:BPMNShape id="Activity_1pdtlxj_di" bpmnElement="Activity_1pdtlxj">
         <dc:Bounds x="423" y="701" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0zxqmhg_di" bpmnElement="Event_02gf3ei">
-        <dc:Bounds x="455" y="92" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="462" y="135" width="22" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0s99n4n_di" bpmnElement="Event_07db4i1">
         <dc:Bounds x="452" y="836" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -237,6 +249,14 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1kajar9_di" bpmnElement="Activity_0ogwlow">
         <dc:Bounds x="620" y="910" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0inz0ib_di" bpmnElement="Activity_167c1gq">
+        <dc:Bounds x="423" y="70" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0k2yt8j_di" bpmnElement="Activity_1b9lhg4">
+        <dc:Bounds x="810" y="910" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0figpgf_di" bpmnElement="Flow_0figpgf">
@@ -348,9 +368,9 @@
       <bpmndi:BPMNEdge id="Flow_1nxsygr_di" bpmnElement="Flow_1nxsygr">
         <di:waypoint x="321" y="245" />
         <di:waypoint x="321" y="110" />
-        <di:waypoint x="455" y="110" />
+        <di:waypoint x="423" y="110" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="362" y="83" width="22" height="14" />
+          <dc:Bounds x="360" y="83" width="22" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0150u75_di" bpmnElement="Flow_0150u75">
@@ -365,8 +385,17 @@
         <di:waypoint x="530" y="950" />
         <di:waypoint x="620" y="950" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1igrzok_di" bpmnElement="Flow_1igrzok">
+      <bpmndi:BPMNEdge id="Flow_13r2ts0_di" bpmnElement="Flow_13r2ts0">
+        <di:waypoint x="523" y="110" />
+        <di:waypoint x="979" y="110" />
+        <di:waypoint x="979" y="323" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gl18c0_di" bpmnElement="Flow_0gl18c0">
         <di:waypoint x="720" y="950" />
+        <di:waypoint x="810" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g09equ_di" bpmnElement="Flow_0g09equ">
+        <di:waypoint x="910" y="950" />
         <di:waypoint x="979" y="950" />
         <di:waypoint x="979" y="373" />
       </bpmndi:BPMNEdge>

--- a/src/main/resources/exploding-kittens-action.bpmn
+++ b/src/main/resources/exploding-kittens-action.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1c0uu3w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1c0uu3w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
   <bpmn:process id="exploding-kittens-action" name="Exploding Kittens: Apply a card action" isExecutable="true">
     <bpmn:startEvent id="Event_1m08pf0" name="Apply Action">
       <bpmn:outgoing>Flow_0figpgf</bpmn:outgoing>
@@ -14,6 +14,7 @@
       <bpmn:outgoing>Flow_0qpt4bc</bpmn:outgoing>
       <bpmn:outgoing>Flow_1y2momm</bpmn:outgoing>
       <bpmn:outgoing>Flow_1nxsygr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0150u75</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:serviceTask id="Activity_114z54y" name="Select Player">
       <bpmn:extensionElements>
@@ -77,6 +78,7 @@
       <bpmn:incoming>Flow_1pvbc88</bpmn:incoming>
       <bpmn:incoming>Flow_1pyk8o2</bpmn:incoming>
       <bpmn:incoming>Flow_1xnd7rf</bpmn:incoming>
+      <bpmn:incoming>Flow_1igrzok</bpmn:incoming>
       <bpmn:outgoing>Flow_0n68dzy</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="Event_0mubhxj" name="Action applied">
@@ -142,126 +144,31 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1jn3jhb</bpmn:incoming>
     </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0150u75" name="Catomic Bomb" sourceRef="Gateway_1pqfwv5" targetRef="Activity_1bz0snu">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= action = "atomic"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Activity_1bz0snu" name="Shuffle deck">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="shuffle" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0150u75</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rqecyx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1rqecyx" sourceRef="Activity_1bz0snu" targetRef="Activity_0ogwlow" />
+    <bpmn:serviceTask id="Activity_0ogwlow" name="Move exploding kittens to top of deck">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="atomic" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1rqecyx</bpmn:incoming>
+      <bpmn:outgoing>Flow_1igrzok</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1igrzok" sourceRef="Activity_0ogwlow" targetRef="Gateway_0547r8f" />
   </bpmn:process>
   <bpmn:error id="Error_0nbjl10" name="skip" errorCode="skip" />
   <bpmn:error id="Error_0fp8pba" name="attack" errorCode="attack" />
   <bpmn:error id="Error_0gl9bie" name="draw" errorCode="draw" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="exploding-kittens-action">
-      <bpmndi:BPMNEdge id="Flow_1nxsygr_di" bpmnElement="Flow_1nxsygr">
-        <di:waypoint x="321" y="245" />
-        <di:waypoint x="321" y="110" />
-        <di:waypoint x="455" y="110" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="362" y="83" width="22" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0n68dzy_di" bpmnElement="Flow_0n68dzy">
-        <di:waypoint x="1004" y="348" />
-        <di:waypoint x="1081" y="348" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xnd7rf_di" bpmnElement="Flow_1xnd7rf">
-        <di:waypoint x="523" y="741" />
-        <di:waypoint x="979" y="741" />
-        <di:waypoint x="979" y="373" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pyk8o2_di" bpmnElement="Flow_1pyk8o2">
-        <di:waypoint x="700" y="640" />
-        <di:waypoint x="979" y="640" />
-        <di:waypoint x="979" y="373" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pvbc88_di" bpmnElement="Flow_1pvbc88">
-        <di:waypoint x="700" y="447" />
-        <di:waypoint x="979" y="447" />
-        <di:waypoint x="979" y="373" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1n9w2pn_di" bpmnElement="Flow_1n9w2pn">
-        <di:waypoint x="877" y="348" />
-        <di:waypoint x="954" y="348" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09f3fgj_di" bpmnElement="Flow_09f3fgj">
-        <di:waypoint x="700" y="348" />
-        <di:waypoint x="777" y="348" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0dk6rfu_di" bpmnElement="Flow_0dk6rfu">
-        <di:waypoint x="523" y="640" />
-        <di:waypoint x="600" y="640" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1c7ix4r_di" bpmnElement="Flow_1c7ix4r">
-        <di:waypoint x="523" y="543" />
-        <di:waypoint x="979" y="543" />
-        <di:waypoint x="979" y="373" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tjilsp_di" bpmnElement="Flow_1tjilsp">
-        <di:waypoint x="523" y="447" />
-        <di:waypoint x="600" y="447" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09qagsj_di" bpmnElement="Flow_09qagsj">
-        <di:waypoint x="523" y="348" />
-        <di:waypoint x="600" y="348" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1y2momm_di" bpmnElement="Flow_1y2momm">
-        <di:waypoint x="321" y="295" />
-        <di:waypoint x="321" y="741" />
-        <di:waypoint x="423" y="741" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="332" y="723" width="34" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qpt4bc_di" bpmnElement="Flow_0qpt4bc">
-        <di:waypoint x="321" y="295" />
-        <di:waypoint x="321" y="854" />
-        <di:waypoint x="452" y="854" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="342" y="833" width="89" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ypnsor_di" bpmnElement="Flow_1ypnsor">
-        <di:waypoint x="321" y="295" />
-        <di:waypoint x="321" y="640" />
-        <di:waypoint x="423" y="640" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="334" y="614" width="76" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f83dd0_di" bpmnElement="Flow_1f83dd0">
-        <di:waypoint x="321" y="295" />
-        <di:waypoint x="321" y="543" />
-        <di:waypoint x="423" y="543" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="334" y="517" width="73" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_068xfqe_di" bpmnElement="Flow_068xfqe">
-        <di:waypoint x="321" y="295" />
-        <di:waypoint x="321" y="447" />
-        <di:waypoint x="423" y="447" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="339" y="412" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02bpcxf_di" bpmnElement="Flow_02bpcxf">
-        <di:waypoint x="346" y="270" />
-        <di:waypoint x="381" y="270" />
-        <di:waypoint x="381" y="348" />
-        <di:waypoint x="423" y="348" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="389" y="325" width="29" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jn3jhb_di" bpmnElement="Flow_1jn3jhb">
-        <di:waypoint x="346" y="270" />
-        <di:waypoint x="381" y="270" />
-        <di:waypoint x="381" y="239" />
-        <di:waypoint x="423" y="239" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="384" y="221" width="32" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0figpgf_di" bpmnElement="Flow_0figpgf">
-        <di:waypoint x="168" y="270" />
-        <di:waypoint x="296" y="270" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m08pf0_di" bpmnElement="Event_1m08pf0">
         <dc:Bounds x="132" y="252" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -325,6 +232,144 @@
       <bpmndi:BPMNShape id="Activity_06wb6zt_di" bpmnElement="Activity_06wb6zt">
         <dc:Bounds x="423" y="199" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ysnkgo_di" bpmnElement="Activity_1bz0snu">
+        <dc:Bounds x="430" y="910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kajar9_di" bpmnElement="Activity_0ogwlow">
+        <dc:Bounds x="620" y="910" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0figpgf_di" bpmnElement="Flow_0figpgf">
+        <di:waypoint x="168" y="270" />
+        <di:waypoint x="296" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jn3jhb_di" bpmnElement="Flow_1jn3jhb">
+        <di:waypoint x="346" y="270" />
+        <di:waypoint x="381" y="270" />
+        <di:waypoint x="381" y="239" />
+        <di:waypoint x="423" y="239" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="384" y="221" width="32" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02bpcxf_di" bpmnElement="Flow_02bpcxf">
+        <di:waypoint x="346" y="270" />
+        <di:waypoint x="381" y="270" />
+        <di:waypoint x="381" y="348" />
+        <di:waypoint x="423" y="348" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="389" y="325" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_068xfqe_di" bpmnElement="Flow_068xfqe">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="447" />
+        <di:waypoint x="423" y="447" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="412" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f83dd0_di" bpmnElement="Flow_1f83dd0">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="543" />
+        <di:waypoint x="423" y="543" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="334" y="517" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ypnsor_di" bpmnElement="Flow_1ypnsor">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="640" />
+        <di:waypoint x="423" y="640" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="334" y="614" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qpt4bc_di" bpmnElement="Flow_0qpt4bc">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="854" />
+        <di:waypoint x="452" y="854" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="342" y="833" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1y2momm_di" bpmnElement="Flow_1y2momm">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="741" />
+        <di:waypoint x="423" y="741" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="332" y="723" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09qagsj_di" bpmnElement="Flow_09qagsj">
+        <di:waypoint x="523" y="348" />
+        <di:waypoint x="600" y="348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tjilsp_di" bpmnElement="Flow_1tjilsp">
+        <di:waypoint x="523" y="447" />
+        <di:waypoint x="600" y="447" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c7ix4r_di" bpmnElement="Flow_1c7ix4r">
+        <di:waypoint x="523" y="543" />
+        <di:waypoint x="979" y="543" />
+        <di:waypoint x="979" y="373" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dk6rfu_di" bpmnElement="Flow_0dk6rfu">
+        <di:waypoint x="523" y="640" />
+        <di:waypoint x="600" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09f3fgj_di" bpmnElement="Flow_09f3fgj">
+        <di:waypoint x="700" y="348" />
+        <di:waypoint x="777" y="348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1n9w2pn_di" bpmnElement="Flow_1n9w2pn">
+        <di:waypoint x="877" y="348" />
+        <di:waypoint x="954" y="348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pvbc88_di" bpmnElement="Flow_1pvbc88">
+        <di:waypoint x="700" y="447" />
+        <di:waypoint x="979" y="447" />
+        <di:waypoint x="979" y="373" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pyk8o2_di" bpmnElement="Flow_1pyk8o2">
+        <di:waypoint x="700" y="640" />
+        <di:waypoint x="979" y="640" />
+        <di:waypoint x="979" y="373" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xnd7rf_di" bpmnElement="Flow_1xnd7rf">
+        <di:waypoint x="523" y="741" />
+        <di:waypoint x="979" y="741" />
+        <di:waypoint x="979" y="373" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n68dzy_di" bpmnElement="Flow_0n68dzy">
+        <di:waypoint x="1004" y="348" />
+        <di:waypoint x="1081" y="348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nxsygr_di" bpmnElement="Flow_1nxsygr">
+        <di:waypoint x="321" y="245" />
+        <di:waypoint x="321" y="110" />
+        <di:waypoint x="455" y="110" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="362" y="83" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0150u75_di" bpmnElement="Flow_0150u75">
+        <di:waypoint x="321" y="295" />
+        <di:waypoint x="321" y="950" />
+        <di:waypoint x="430" y="950" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="344" y="933" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rqecyx_di" bpmnElement="Flow_1rqecyx">
+        <di:waypoint x="530" y="950" />
+        <di:waypoint x="620" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1igrzok_di" bpmnElement="Flow_1igrzok">
+        <di:waypoint x="720" y="950" />
+        <di:waypoint x="979" y="950" />
+        <di:waypoint x="979" y="373" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/exploding-kittens-turn.bpmn
+++ b/src/main/resources/exploding-kittens-turn.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0nftw3c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0nftw3c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
   <bpmn:process id="exploding-kittens-turn" name="Exploding Kittens: One turn" isExecutable="true">
     <bpmn:endEvent id="Event_0fr7jpt" name="Turn ends">
       <bpmn:incoming>Flow_0jpbaoe</bpmn:incoming>
@@ -7,7 +7,7 @@
     <bpmn:exclusiveGateway id="Gateway_0xfbl9m">
       <bpmn:incoming>Flow_1okimbj</bpmn:incoming>
       <bpmn:incoming>Flow_1oo45ce</bpmn:incoming>
-      <bpmn:incoming>Flow_0ho77xy</bpmn:incoming>
+      <bpmn:incoming>Flow_00i4t8l</bpmn:incoming>
       <bpmn:outgoing>Flow_12urn3u</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:serviceTask id="Activity_1f75peo" name="Inject Exploding Kitten Card">
@@ -67,7 +67,7 @@
     </bpmn:exclusiveGateway>
     <bpmn:exclusiveGateway id="Gateway_1e1tigp">
       <bpmn:incoming>Flow_0c078nq</bpmn:incoming>
-      <bpmn:incoming>Flow_0qlreve</bpmn:incoming>
+      <bpmn:incoming>Flow_02dt5ph</bpmn:incoming>
       <bpmn:outgoing>Flow_1x8hr0v</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:startEvent id="Event_1q1flbr" name="Start Turn">
@@ -131,10 +131,6 @@
       <bpmn:incoming>Flow_0p5gfaf</bpmn:incoming>
       <bpmn:outgoing>Flow_0qlreve</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:boundaryEvent id="Event_021jqmd" name="Skip" attachedToRef="Activity_1u7t6wr">
-      <bpmn:outgoing>Flow_0ho77xy</bpmn:outgoing>
-      <bpmn:errorEventDefinition id="ErrorEventDefinition_0ecfmxh" errorRef="Error_1cpscbz" />
-    </bpmn:boundaryEvent>
     <bpmn:boundaryEvent id="Event_03q9zos" name="Draw action" attachedToRef="Activity_1u7t6wr">
       <bpmn:outgoing>Flow_0ka4stc</bpmn:outgoing>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_1t3elwg" errorRef="Error_1rqoh1y" />
@@ -142,7 +138,6 @@
     <bpmn:sequenceFlow id="Flow_0jpbaoe" sourceRef="Activity_0dbspy5" targetRef="Event_0fr7jpt" />
     <bpmn:sequenceFlow id="Flow_1okimbj" name="No" sourceRef="Gateway_07y2z0h" targetRef="Gateway_0xfbl9m" />
     <bpmn:sequenceFlow id="Flow_1oo45ce" sourceRef="Activity_1f75peo" targetRef="Gateway_0xfbl9m" />
-    <bpmn:sequenceFlow id="Flow_0ho77xy" sourceRef="Event_021jqmd" targetRef="Gateway_0xfbl9m" />
     <bpmn:sequenceFlow id="Flow_12urn3u" sourceRef="Gateway_0xfbl9m" targetRef="Activity_0dbspy5" />
     <bpmn:sequenceFlow id="Flow_1lwwl5w" sourceRef="Activity_07u3vb9" targetRef="Activity_1f75peo" />
     <bpmn:sequenceFlow id="Flow_07e9c08" name="Yes" sourceRef="Gateway_1k627g1" targetRef="Activity_07u3vb9">
@@ -165,7 +160,7 @@
     <bpmn:sequenceFlow id="Flow_0c078nq" name="Nope! is played (odd amount of times)" sourceRef="Gateway_06d22gh" targetRef="Gateway_1e1tigp">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">= odd(playedNopeCards)</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0qlreve" sourceRef="Activity_1u7t6wr" targetRef="Gateway_1e1tigp" />
+    <bpmn:sequenceFlow id="Flow_0qlreve" sourceRef="Activity_1u7t6wr" targetRef="Gateway_1w8ii6w" />
     <bpmn:sequenceFlow id="Flow_1x8hr0v" sourceRef="Gateway_1e1tigp" targetRef="Activity_1g6nn2f" />
     <bpmn:sequenceFlow id="Flow_0ylqmpp" sourceRef="Event_1q1flbr" targetRef="Activity_1g6nn2f" />
     <bpmn:sequenceFlow id="Flow_073v58q" sourceRef="Activity_1e0llmm" targetRef="Activity_0vxp3f4" />
@@ -181,145 +176,21 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_062v0f6</bpmn:incoming>
     </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1w8ii6w" name="End turn?" default="Flow_02dt5ph">
+      <bpmn:incoming>Flow_0qlreve</bpmn:incoming>
+      <bpmn:outgoing>Flow_02dt5ph</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00i4t8l</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_02dt5ph" name="No" sourceRef="Gateway_1w8ii6w" targetRef="Gateway_1e1tigp" />
+    <bpmn:sequenceFlow id="Flow_00i4t8l" name="Yes" sourceRef="Gateway_1w8ii6w" targetRef="Gateway_0xfbl9m">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=endTurn</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmn:error id="Error_0gms9au" name="explodingKitten" errorCode="explodingKitten" />
   <bpmn:error id="Error_1cpscbz" name="skip" errorCode="skip" />
   <bpmn:error id="Error_1rqoh1y" name="draw" errorCode="draw" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="exploding-kittens-turn">
-      <bpmndi:BPMNEdge id="Flow_0p5gfaf_di" bpmnElement="Flow_0p5gfaf">
-        <di:waypoint x="1024" y="287" />
-        <di:waypoint x="1189" y="287" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1069" y="240" width="79" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1cgwkmu_di" bpmnElement="Flow_1cgwkmu">
-        <di:waypoint x="889" y="287" />
-        <di:waypoint x="974" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_073v58q_di" bpmnElement="Flow_073v58q">
-        <di:waypoint x="719" y="287" />
-        <di:waypoint x="789" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ylqmpp_di" bpmnElement="Flow_0ylqmpp">
-        <di:waypoint x="198" y="287" />
-        <di:waypoint x="279" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1x8hr0v_di" bpmnElement="Flow_1x8hr0v">
-        <di:waypoint x="974" y="110" />
-        <di:waypoint x="329" y="110" />
-        <di:waypoint x="329" y="247" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qlreve_di" bpmnElement="Flow_0qlreve">
-        <di:waypoint x="1289" y="287" />
-        <di:waypoint x="1369" y="287" />
-        <di:waypoint x="1369" y="110" />
-        <di:waypoint x="1024" y="110" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0c078nq_di" bpmnElement="Flow_0c078nq">
-        <di:waypoint x="999" y="262" />
-        <di:waypoint x="999" y="135" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1011" y="181" width="76" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fq9dl3_di" bpmnElement="Flow_0fq9dl3">
-        <di:waypoint x="501" y="287" />
-        <di:waypoint x="619" y="287" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="533" y="265" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1kmn2ut_di" bpmnElement="Flow_1kmn2ut">
-        <di:waypoint x="379" y="287" />
-        <di:waypoint x="451" y="287" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ka4stc_di" bpmnElement="Flow_0ka4stc">
-        <di:waypoint x="1189" y="345" />
-        <di:waypoint x="1189" y="610" />
-        <di:waypoint x="1279" y="610" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kp347j_di" bpmnElement="Flow_0kp347j">
-        <di:waypoint x="476" y="312" />
-        <di:waypoint x="476" y="716" />
-        <di:waypoint x="1279" y="716" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="495" y="373" width="47" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v4ed40_di" bpmnElement="Flow_0v4ed40">
-        <di:waypoint x="1379" y="716" />
-        <di:waypoint x="1479" y="716" />
-        <di:waypoint x="1479" y="635" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0zwopxh_di" bpmnElement="Flow_0zwopxh">
-        <di:waypoint x="1379" y="610" />
-        <di:waypoint x="1454" y="610" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1v4t1sf_di" bpmnElement="Flow_1v4t1sf">
-        <di:waypoint x="1504" y="610" />
-        <di:waypoint x="1614" y="610" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0gwhj37_di" bpmnElement="Flow_0gwhj37">
-        <di:waypoint x="1639" y="635" />
-        <di:waypoint x="1639" y="822" />
-        <di:waypoint x="1750" y="822" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1679" y="795" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_062v0f6_di" bpmnElement="Flow_062v0f6">
-        <di:waypoint x="1924" y="847" />
-        <di:waypoint x="1924" y="971" />
-        <di:waypoint x="2001" y="971" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1939" y="946" width="14" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1melxq9_di" bpmnElement="Flow_1melxq9">
-        <di:waypoint x="1850" y="822" />
-        <di:waypoint x="1899" y="822" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07e9c08_di" bpmnElement="Flow_07e9c08">
-        <di:waypoint x="1924" y="797" />
-        <di:waypoint x="1924" y="700" />
-        <di:waypoint x="2001" y="700" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1937" y="680" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lwwl5w_di" bpmnElement="Flow_1lwwl5w">
-        <di:waypoint x="2101" y="700" />
-        <di:waypoint x="2199" y="700" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12urn3u_di" bpmnElement="Flow_12urn3u">
-        <di:waypoint x="2465" y="490" />
-        <di:waypoint x="2532" y="490" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ho77xy_di" bpmnElement="Flow_0ho77xy">
-        <di:waypoint x="1289" y="345" />
-        <di:waypoint x="1289" y="390" />
-        <di:waypoint x="2440" y="390" />
-        <di:waypoint x="2440" y="465" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1oo45ce_di" bpmnElement="Flow_1oo45ce">
-        <di:waypoint x="2299" y="700" />
-        <di:waypoint x="2440" y="700" />
-        <di:waypoint x="2440" y="515" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1okimbj_di" bpmnElement="Flow_1okimbj">
-        <di:waypoint x="1639" y="585" />
-        <di:waypoint x="1639" y="490" />
-        <di:waypoint x="2415" y="490" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1687" y="503" width="14" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jpbaoe_di" bpmnElement="Flow_0jpbaoe">
-        <di:waypoint x="2632" y="490" />
-        <di:waypoint x="2702" y="490" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0fr7jpt_di" bpmnElement="Event_0fr7jpt">
         <dc:Bounds x="2702" y="472" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -398,18 +269,159 @@
       <bpmndi:BPMNShape id="Activity_1i8hxil_di" bpmnElement="Activity_1i8hxil">
         <dc:Bounds x="2001" y="931" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1w8ii6w_di" bpmnElement="Gateway_1w8ii6w" isMarkerVisible="true">
+        <dc:Bounds x="1365" y="262" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1366" y="322" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_03q9zos_di" bpmnElement="Event_03q9zos">
         <dc:Bounds x="1171" y="309" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1208" y="341" width="58" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_021jqmd_di" bpmnElement="Event_021jqmd">
-        <dc:Bounds x="1271" y="309" width="36" height="36" />
+      <bpmndi:BPMNEdge id="Flow_0jpbaoe_di" bpmnElement="Flow_0jpbaoe">
+        <di:waypoint x="2632" y="490" />
+        <di:waypoint x="2702" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1okimbj_di" bpmnElement="Flow_1okimbj">
+        <di:waypoint x="1639" y="585" />
+        <di:waypoint x="1639" y="490" />
+        <di:waypoint x="2415" y="490" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1316" y="330" width="22" height="14" />
+          <dc:Bounds x="1687" y="503" width="14" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oo45ce_di" bpmnElement="Flow_1oo45ce">
+        <di:waypoint x="2299" y="700" />
+        <di:waypoint x="2440" y="700" />
+        <di:waypoint x="2440" y="515" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12urn3u_di" bpmnElement="Flow_12urn3u">
+        <di:waypoint x="2465" y="490" />
+        <di:waypoint x="2532" y="490" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lwwl5w_di" bpmnElement="Flow_1lwwl5w">
+        <di:waypoint x="2101" y="700" />
+        <di:waypoint x="2199" y="700" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07e9c08_di" bpmnElement="Flow_07e9c08">
+        <di:waypoint x="1924" y="797" />
+        <di:waypoint x="1924" y="700" />
+        <di:waypoint x="2001" y="700" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1937" y="680" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1melxq9_di" bpmnElement="Flow_1melxq9">
+        <di:waypoint x="1850" y="822" />
+        <di:waypoint x="1899" y="822" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_062v0f6_di" bpmnElement="Flow_062v0f6">
+        <di:waypoint x="1924" y="847" />
+        <di:waypoint x="1924" y="971" />
+        <di:waypoint x="2001" y="971" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1939" y="946" width="14" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gwhj37_di" bpmnElement="Flow_0gwhj37">
+        <di:waypoint x="1639" y="635" />
+        <di:waypoint x="1639" y="822" />
+        <di:waypoint x="1750" y="822" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1679" y="795" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1v4t1sf_di" bpmnElement="Flow_1v4t1sf">
+        <di:waypoint x="1504" y="610" />
+        <di:waypoint x="1614" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zwopxh_di" bpmnElement="Flow_0zwopxh">
+        <di:waypoint x="1379" y="610" />
+        <di:waypoint x="1454" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v4ed40_di" bpmnElement="Flow_0v4ed40">
+        <di:waypoint x="1379" y="716" />
+        <di:waypoint x="1479" y="716" />
+        <di:waypoint x="1479" y="635" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kp347j_di" bpmnElement="Flow_0kp347j">
+        <di:waypoint x="476" y="312" />
+        <di:waypoint x="476" y="716" />
+        <di:waypoint x="1279" y="716" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="495" y="373" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ka4stc_di" bpmnElement="Flow_0ka4stc">
+        <di:waypoint x="1189" y="345" />
+        <di:waypoint x="1189" y="610" />
+        <di:waypoint x="1279" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kmn2ut_di" bpmnElement="Flow_1kmn2ut">
+        <di:waypoint x="379" y="287" />
+        <di:waypoint x="451" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fq9dl3_di" bpmnElement="Flow_0fq9dl3">
+        <di:waypoint x="501" y="287" />
+        <di:waypoint x="619" y="287" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="533" y="265" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c078nq_di" bpmnElement="Flow_0c078nq">
+        <di:waypoint x="999" y="262" />
+        <di:waypoint x="999" y="135" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1011" y="181" width="76" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qlreve_di" bpmnElement="Flow_0qlreve">
+        <di:waypoint x="1289" y="287" />
+        <di:waypoint x="1365" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1x8hr0v_di" bpmnElement="Flow_1x8hr0v">
+        <di:waypoint x="974" y="110" />
+        <di:waypoint x="329" y="110" />
+        <di:waypoint x="329" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ylqmpp_di" bpmnElement="Flow_0ylqmpp">
+        <di:waypoint x="198" y="287" />
+        <di:waypoint x="279" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_073v58q_di" bpmnElement="Flow_073v58q">
+        <di:waypoint x="719" y="287" />
+        <di:waypoint x="789" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cgwkmu_di" bpmnElement="Flow_1cgwkmu">
+        <di:waypoint x="889" y="287" />
+        <di:waypoint x="974" y="287" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p5gfaf_di" bpmnElement="Flow_0p5gfaf">
+        <di:waypoint x="1024" y="287" />
+        <di:waypoint x="1189" y="287" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1069" y="240" width="79" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02dt5ph_di" bpmnElement="Flow_02dt5ph">
+        <di:waypoint x="1390" y="262" />
+        <di:waypoint x="1390" y="110" />
+        <di:waypoint x="1024" y="110" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1398" y="183" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00i4t8l_di" bpmnElement="Flow_00i4t8l">
+        <di:waypoint x="1415" y="287" />
+        <di:waypoint x="2440" y="287" />
+        <di:waypoint x="2440" y="465" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1432" y="265" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
> Remove the exploding kittens from the deck. Shuffle the deck. Put all the kittens face down on top. Your turn ends after playing this card.

This PR adds the Catomic Bomb card to the deck. There is only one copy of this card in the game, regardless of the amount of players.
When drawn the deck is shuffled, all remaining exploding kittens are put at the top and the player's turn is ended.

For this I also changed how Skip works. Before it would throw an error which was caught to end the turn. I've switched this to a variable, because throwing an error terminates the call activity. As a result any changes done to the deck are not propagated to the parent process.
